### PR TITLE
Avoid possible code dependency over an undefined value

### DIFF
--- a/Solver/EigenLDLTSolver.cc
+++ b/Solver/EigenLDLTSolver.cc
@@ -34,7 +34,7 @@ namespace COMISO {
 
   EigenLDLTSolver::EigenLDLTSolver() : n_(0)
 {
-
+  show_timings_ = false;
 }
 
 


### PR DESCRIPTION
As in the description, found with valgrind.