### PR TITLE
update openblas dll to be v0.3.6

### DIFF
--- a/ext/gmm-4.2/include/gmm/gmm_domain_decomp.h
+++ b/ext/gmm-4.2/include/gmm/gmm_domain_decomp.h
@@ -81,7 +81,7 @@ namespace gmm {
     std::vector<size_type> ns(dim), na(dim), nu(dim);
     for (size_type i = 0; i < nbpts; ++i) {
       for (int k = 0; k < dim; ++k) {
-	register double a = (pts[i][k] - pmin[k]) / msize;
+	double a = (pts[i][k] - pmin[k]) / msize;
 	ns[k] = size_type(a) - 1; na[k] = 0;
 	pts1[k] = int(a + overlap); pts2[k] = int(ceil(a-1.0-overlap));
       }


### PR DESCRIPTION
This fixes the runtime error of libigl CoMISo on Windows under Release mode.

Related libigl issue: [#1050](https://github.com/libigl/libigl/issues/1050)

For us, the problem was similar as in our application runs fine in debug mode but not in release due to the library not being the most up-to-date. After replacing it with the [v0.3.6](https://sourceforge.net/projects/openblas/files/v0.3.6/) (released mid August), the issue gets resolved. 
In fact, using [v0.2.15](https://sourceforge.net/projects/openblas/files/v0.2.15/) (the immediate next version of the current version) also gets rid of the runtime error. 

Although as in the original post, "deleting the BLAS libraries from CoMISo and linking instead to OpenBLAS compiled from source" is the right way to fix it, updating the dll will also fix it and doesn't require other changes. 
This is a temporary solution until anyone implements what is mentioned in [this comment](https://github.com/libigl/libigl/issues/1050#issuecomment-449509616).