### PR TITLE
fix eigen include when Eigen3::Eigen is defined

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,11 @@ target_include_directories(CoMISo PUBLIC
   "${CMAKE_CURRENT_SOURCE_DIR}/ext/gmm-4.2/include")
 target_compile_definitions(CoMISo PUBLIC -DINCLUDE_TEMPLATES)
 
+if(TARGET Eigen3::Eigen)
+  # If an imported target already exists, use it
+  target_link_libraries(CoMISo PUBLIC Eigen3::Eigen)
+endif()
+
 # Generate position independent code
 set_target_properties(CoMISo PROPERTIES POSITION_INDEPENDENT_CODE ON)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,10 +20,7 @@ target_include_directories(CoMISo PUBLIC
   "${CMAKE_CURRENT_SOURCE_DIR}/ext/gmm-4.2/include")
 target_compile_definitions(CoMISo PUBLIC -DINCLUDE_TEMPLATES)
 
-if(TARGET Eigen3::Eigen)
-  # If an imported target already exists, use it
-  target_link_libraries(CoMISo PUBLIC Eigen3::Eigen)
-endif()
+target_link_libraries(CoMISo PUBLIC Eigen3::Eigen)
 
 # Generate position independent code
 set_target_properties(CoMISo PROPERTIES POSITION_INDEPENDENT_CODE ON)


### PR DESCRIPTION
following libigl.cmake line 98~108
```
# Eigen
if(TARGET Eigen3::Eigen)
  # If an imported target already exists, use it
  target_link_libraries(igl_common INTERFACE Eigen3::Eigen)
else()
  igl_download_eigen()
  target_include_directories(igl_common SYSTEM INTERFACE
    $<BUILD_INTERFACE:${LIBIGL_EXTERNAL}/eigen>
    $<INSTALL_INTERFACE:include>
  )
endif()
```

when add libigl as a subproject by calling add_subdirectory(), if Eigen3::Eigen is already defined then libigl.cmake won't download Eigen and would only link to Eigen3::Eigen, in this case CoMiSo's eigen include would fail because `${CMAKE_CURRENT_SOURCE_DIR}/../eigen` doesn't exists